### PR TITLE
refactor(validator): 각 도메인에 대한 validator class를 생성하고 A service에선 A repository만 참조하게 변경

### DIFF
--- a/src/main/java/Team02/BackEnd/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/Team02/BackEnd/apiPayload/code/status/ErrorStatus.java
@@ -31,8 +31,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Feedback 관련 응답
     _FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "FEEDBACK4001", "해당 피드백이 없습니다"),
+    _FAST_API_FEEDBACK_NULL(HttpStatus.BAD_REQUEST, "FEEDBACK4002", "Fast api return null"),
+
+    // Answer 관련 응답
     _ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER4001", "해당 답변이 없습니다."),
-    _FAST_API_FEEDBACK_NULL(HttpStatus.BAD_REQUEST, "FEEDBACK4002", "Fast api return null");
+
+    // Question 관련 응답
+    _QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION4001", "해당 질문이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Team02/BackEnd/apiPayload/exception/handler/QuestionHandler.java
+++ b/src/main/java/Team02/BackEnd/apiPayload/exception/handler/QuestionHandler.java
@@ -1,0 +1,11 @@
+package Team02.BackEnd.apiPayload.exception.handler;
+
+import Team02.BackEnd.apiPayload.code.BaseErrorCode;
+import Team02.BackEnd.apiPayload.exception.GeneralException;
+
+public class QuestionHandler extends GeneralException {
+
+    public QuestionHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/Team02/BackEnd/exception/validator/AnswerValidator.java
+++ b/src/main/java/Team02/BackEnd/exception/validator/AnswerValidator.java
@@ -1,0 +1,14 @@
+package Team02.BackEnd.exception.validator;
+
+import Team02.BackEnd.apiPayload.code.status.ErrorStatus;
+import Team02.BackEnd.apiPayload.exception.handler.AnswerHandler;
+import Team02.BackEnd.domain.Answer;
+
+public class AnswerValidator {
+
+    public static void validateAnswerIsNotNull(Answer answer) {
+        if (answer == null) {
+            throw new AnswerHandler(ErrorStatus._ANSWER_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/Team02/BackEnd/exception/validator/FeedbackValidator.java
+++ b/src/main/java/Team02/BackEnd/exception/validator/FeedbackValidator.java
@@ -1,0 +1,14 @@
+package Team02.BackEnd.exception.validator;
+
+import Team02.BackEnd.apiPayload.code.status.ErrorStatus;
+import Team02.BackEnd.apiPayload.exception.handler.FeedbackHandler;
+import Team02.BackEnd.domain.Feedback;
+
+public class FeedbackValidator {
+
+    public static void validateFeedbackIsNotNull(Feedback feedback) {
+        if (feedback == null) {
+            throw new FeedbackHandler(ErrorStatus._FEEDBACK_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/Team02/BackEnd/exception/validator/QuestionValidator.java
+++ b/src/main/java/Team02/BackEnd/exception/validator/QuestionValidator.java
@@ -1,0 +1,14 @@
+package Team02.BackEnd.exception.validator;
+
+import Team02.BackEnd.apiPayload.code.status.ErrorStatus;
+import Team02.BackEnd.apiPayload.exception.handler.QuestionHandler;
+import Team02.BackEnd.domain.Question;
+
+public class QuestionValidator {
+
+    public static void validateQuestionIsNotNull(Question question) {
+        if (question == null) {
+            throw new QuestionHandler(ErrorStatus._QUESTION_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/Team02/BackEnd/exception/validator/UserValidator.java
+++ b/src/main/java/Team02/BackEnd/exception/validator/UserValidator.java
@@ -1,0 +1,14 @@
+package Team02.BackEnd.exception.validator;
+
+import Team02.BackEnd.apiPayload.code.status.ErrorStatus;
+import Team02.BackEnd.apiPayload.exception.handler.UserHandler;
+import Team02.BackEnd.domain.oauth.User;
+
+public class UserValidator {
+
+    public static void validateUserIsNotNull(User user) {
+        if (user == null) {
+            throw new UserHandler(ErrorStatus._USER_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/Team02/BackEnd/service/AnswerService.java
+++ b/src/main/java/Team02/BackEnd/service/AnswerService.java
@@ -1,14 +1,11 @@
 package Team02.BackEnd.service;
 
-import Team02.BackEnd.apiPayload.code.status.ErrorStatus;
-import Team02.BackEnd.apiPayload.exception.handler.UserHandler;
 import Team02.BackEnd.converter.AnswerConverter;
 import Team02.BackEnd.domain.Answer;
 import Team02.BackEnd.domain.Question;
 import Team02.BackEnd.domain.oauth.User;
-import Team02.BackEnd.jwt.service.JwtService;
+import Team02.BackEnd.exception.validator.AnswerValidator;
 import Team02.BackEnd.repository.AnswerRepository;
-import Team02.BackEnd.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,21 +13,21 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AnswerService {
 
-    private final JwtService jwtService;
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final AnswerRepository answerRepository;
 
     public Long getAnswerId(String accessToken, Question question) {
-        String email = jwtService.extractEmail(accessToken).orElse(null);
-
-        User user = userRepository.findByEmail(email).orElse(null);
-        if (user == null){
-            throw new UserHandler(ErrorStatus._USER_NOT_FOUND);
-        }
-
+        User user = userService.getUserByToken(accessToken);
         Answer answer = AnswerConverter.toAnswer(user, question);
+
         answerRepository.save(answer);
 
         return answer.getId();
+    }
+
+    public Answer getAnswerByUserId(Long userId) {
+        Answer answer = answerRepository.findByUserId(userId);
+        AnswerValidator.validateAnswerIsNotNull(answer);
+        return answer;
     }
 }

--- a/src/main/java/Team02/BackEnd/service/UserService.java
+++ b/src/main/java/Team02/BackEnd/service/UserService.java
@@ -1,9 +1,8 @@
 package Team02.BackEnd.service;
 
-import Team02.BackEnd.apiPayload.code.status.ErrorStatus;
-import Team02.BackEnd.apiPayload.exception.handler.UserHandler;
 import Team02.BackEnd.domain.oauth.User;
 import Team02.BackEnd.dto.RecordRequestDto.GetVoiceUrlDto;
+import Team02.BackEnd.exception.validator.UserValidator;
 import Team02.BackEnd.jwt.service.JwtService;
 import Team02.BackEnd.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -24,12 +23,7 @@ public class UserService {
     }
 
     public void updateRoleAndVoiceUrl(String accessToken, GetVoiceUrlDto getVoiceUrlDto) {
-        String email = jwtService.extractEmail(accessToken).orElse(null);
-
-        User user = userRepository.findByEmail(email).orElse(null);
-        if (user == null) {
-            throw new UserHandler(ErrorStatus._USER_NOT_FOUND);
-        }
+        User user = getUserByToken(accessToken);
 
         user.updateRole();
         user.updateVoiceUrl(getVoiceUrlDto.getVoiceUrl());
@@ -37,7 +31,17 @@ public class UserService {
         userRepository.save(user);
     }
 
+    public User getUserByToken(String accessToken) {
+        String email = jwtService.extractEmail(accessToken).orElse(null);
+
+        User user = userRepository.findByEmail(email).orElse(null);
+        UserValidator.validateUserIsNotNull(user);
+
+        return user;
+    }
+
     public HashMap<String, Long> getDatesWhenUserDid(String year, String month) {
         return null;
     }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## ✅ PR 유형

어떤 **변경 사항**이 있었나요?

- [x] 새로운 기능 추가
- [ ] 디자인 추가 및 수정
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💻 작업 내용

이번 PR에서 작업한 내용에 대해 설명해주세요.

- 각 도메인 별 validator 클래스 생성
- A service에선 다른 service 클래스를 참조할 순 있지만, 다른 도메인의 repository 클래스는 참조하지 않는다.
-> 그래서 각 service에 getter 메소드를 생성함. 예를 들어 accessToken으로 user를 가져오는 로직을 UserService에 만들고, 다른 service class에서 UserService를 참조해 사용할 수 있게

## 🖼️ 스크린샷

## 🙏 리뷰 요구사항

## ✅ 체크리스트(PR 올리기 전 아래 내용을 확인해 주세요)

- [X] Reviewers를 지정해주세요
- [X] Assignees는 본인을 선택해주세요
- [] label을 선택해주세요
