### PR TITLE
 feat/ 유저가 그 달에 실행한 calendar 체크

### DIFF
--- a/src/main/java/Team02/BackEnd/config/SwaggerConfig.java
+++ b/src/main/java/Team02/BackEnd/config/SwaggerConfig.java
@@ -32,11 +32,12 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         String testToken = jwtService.generateTestToken(); // 스웨거 용 테스트 토큰 생성
+        String test2Token = jwtService.generateTest2Token();
 
         SecurityScheme securityScheme = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
                 .in(SecurityScheme.In.HEADER).name("Authorization")
-                .description("test token: " + testToken); // 디폴트 토큰 나타내기
+                .description("test token: " + testToken + " 구분\n" + test2Token); // 디폴트 토큰 나타내기
 
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 

--- a/src/main/java/Team02/BackEnd/controller/UserController.java
+++ b/src/main/java/Team02/BackEnd/controller/UserController.java
@@ -5,10 +5,8 @@ import static Team02.BackEnd.constant.Constants.ACCESS_TOKEN_REPLACEMENT;
 
 import Team02.BackEnd.apiPayload.ApiResponse;
 import Team02.BackEnd.apiPayload.code.status.SuccessStatus;
-import Team02.BackEnd.jwt.service.JwtService;
 import Team02.BackEnd.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
-    private final JwtService jwtService;
 
     @DeleteMapping("/sign-out")
     public ApiResponse<Void> signOut(@RequestHeader("Authorization") String authorizationHeader) {
@@ -33,9 +30,12 @@ public class UserController {
     }
 
     @GetMapping("/calendars")
-    @Operation(summary = "달력 데이터", description = "쿼리파라미터로 년,월 제공 => 기록 있는 날만 map 형태로 (날짜 : 해당 날짜 answerId) 리턴")
-    public ApiResponse<HashMap<String, Long>> getDatesWhenUserDid(@RequestParam("year") String year,
-                                                                  @RequestParam("month") String month) {
-        return ApiResponse.of(SuccessStatus.GET_DATES_WHEN_USER_DID, userService.getDatesWhenUserDid(year, month));
+    @Operation(summary = "달력 데이터", description = "쿼리 파라미터로 년,월 제공 => getDatesWneUserId[답변 한 날짜] = answerId, 답변 안한 날짜는 0")
+    public ApiResponse<Long[]> getDatesWhenUserDid(@RequestHeader("Authorization") String authorizationHeader,
+                                                   @RequestParam("year") String year,
+                                                   @RequestParam("month") String month) {
+        String accessToken = authorizationHeader.replace(ACCESS_TOKEN_PREFIX, ACCESS_TOKEN_REPLACEMENT);
+        return ApiResponse.of(SuccessStatus.GET_DATES_WHEN_USER_DID,
+                userService.getDatesWhenUserDid(accessToken, year, month));
     }
 }

--- a/src/main/java/Team02/BackEnd/dto/UserResponseDto.java
+++ b/src/main/java/Team02/BackEnd/dto/UserResponseDto.java
@@ -3,4 +3,6 @@ package Team02.BackEnd.dto;
 
 public class UserResponseDto {
 
+    public static class getDatesWhenUserDidDto {
+    }
 }

--- a/src/main/java/Team02/BackEnd/jwt/service/JwtService.java
+++ b/src/main/java/Team02/BackEnd/jwt/service/JwtService.java
@@ -62,6 +62,17 @@ public class JwtService {
                 .sign(Algorithm.HMAC512(secretKey));
     }
 
+    // 테스트용 토큰 생성 메서드 추가
+    public String generateTest2Token() {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
+                .withClaim("unique_id", UUID.randomUUID().toString())
+                .withClaim(EMAIL_CLAIM, "test2@example.com")
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
     /**
      * AccessToken 생성 메서드
      */
@@ -155,6 +166,7 @@ public class JwtService {
                     .getClaim(EMAIL_CLAIM)
                     .asString());
         } catch (Exception e) {
+            System.out.println("검사 할 때 " + accessToken);
             log.error("AccessToken이 유효하지 않습니다.");
             throw new AccessTokenHandler(ErrorStatus._ACCESSTOKEN_NOT_VALID);
         }

--- a/src/main/java/Team02/BackEnd/repository/AnswerRepository.java
+++ b/src/main/java/Team02/BackEnd/repository/AnswerRepository.java
@@ -1,9 +1,17 @@
 package Team02.BackEnd.repository;
 
 import Team02.BackEnd.domain.Answer;
+import Team02.BackEnd.domain.oauth.User;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
     List<Answer> findByUserId(Long userId);
+
+    @Query("SELECT a FROM Answer a WHERE a.user = :user AND YEAR(a.createdAt) = :year AND MONTH(a.createdAt) = :month ORDER BY a.createdAt ASC")
+    List<Answer> findByUserAndYearAndMonth(@Param("user") User user,
+                                           @Param("year") int year,
+                                           @Param("month") int month);
 }

--- a/src/main/java/Team02/BackEnd/service/UserService.java
+++ b/src/main/java/Team02/BackEnd/service/UserService.java
@@ -1,12 +1,15 @@
 package Team02.BackEnd.service;
 
+import Team02.BackEnd.domain.Answer;
 import Team02.BackEnd.domain.oauth.User;
 import Team02.BackEnd.dto.RecordRequestDto.GetVoiceUrlDto;
 import Team02.BackEnd.exception.validator.UserValidator;
 import Team02.BackEnd.jwt.service.JwtService;
+import Team02.BackEnd.repository.AnswerRepository;
 import Team02.BackEnd.repository.UserRepository;
 import jakarta.transaction.Transactional;
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +20,7 @@ public class UserService {
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
+    private final AnswerRepository answerRepository;
 
     public void signOut(String accessToken) {
         //todo 회원 탈퇴시 이 회원과 관련된 모든 DB 데이터 삭제
@@ -40,8 +44,22 @@ public class UserService {
         return user;
     }
 
-    public HashMap<String, Long> getDatesWhenUserDid(String year, String month) {
-        return null;
+    public Long[] getDatesWhenUserDid(String accessToken, String year, String month) {
+        User user = getUserByToken(accessToken);
+
+        Long[] answerIdDidThisPeriod = new Long[32];
+        Arrays.fill(answerIdDidThisPeriod, 0L);
+
+        int yearInt = Integer.parseInt(year);
+        int monthInt = Integer.parseInt(month);
+        List<Answer> answersInPeriod = answerRepository.findByUserAndYearAndMonth(user, yearInt, monthInt);
+
+        for (Answer answer : answersInPeriod) {
+            int day = answer.getCreatedAt().getDayOfMonth();
+            answerIdDidThisPeriod[day - 1] = answer.getId();
+        }
+
+        return answerIdDidThisPeriod;
     }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,11 +1,22 @@
+Insert INTO question(question_index, description)
+values (1, '당신은 어떤 도형을 닮은 것 같나요? 그 도형을 닮은 이유는 무엇인가요? 1분동안 말해보세요!');
+Insert INTO question(question_index, description)
+values (2, '당신은 어떤 색을 닮았다고 생각하나요? 그 색을 닮은 이유는 무엇인가요? 1분 동안 설명해보세요!');
+Insert INTO question(question_index, description)
+values (3, '자신의 성격을 동물로 비유한다면, 어떤 동물에 가까운가요? 그 동물을 닮은 이유를 1분 동안 말해보세요!');
+Insert INTO question(question_index, description)
+values (4, '당신이 가장 좋아하는 계절은 무엇인가요? 그 계절을 좋아하는 이유를 1분 동안 설명해보세요!');
+Insert INTO question(question_index, description)
+values (5, '자신의 인생을 영화로 만든다면, 어떤 장면이 가장 중요하다고 생각하나요? 그 장면을 선택한 이유를 1분 동안 말해보세요!');
+Insert INTO question(question_index, description)
+values (6, '자신을 한 단어로 표현한다면, 어떤 단어가 가장 적합하다고 생각하나요? 그 단어를 닮은 이유를 1분 동안 말해보세요!');
 
-Insert INTO question(question_index, description) values(1, '당신은 어떤 도형을 닮은 것 같나요? 그 도형을 닮은 이유는 무엇인가요? 1분동안 말해보세요!');
-Insert INTO question(question_index, description) values(2, '당신은 어떤 색을 닮았다고 생각하나요? 그 색을 닮은 이유는 무엇인가요? 1분 동안 설명해보세요!');
-Insert INTO question(question_index, description) values(3, '자신의 성격을 동물로 비유한다면, 어떤 동물에 가까운가요? 그 동물을 닮은 이유를 1분 동안 말해보세요!');
-Insert INTO question(question_index, description) values(4, '당신이 가장 좋아하는 계절은 무엇인가요? 그 계절을 좋아하는 이유를 1분 동안 설명해보세요!');
-Insert INTO question(question_index, description) values(5, '자신의 인생을 영화로 만든다면, 어떤 장면이 가장 중요하다고 생각하나요? 그 장면을 선택한 이유를 1분 동안 말해보세요!');
-Insert INTO question(question_index, description) values(6, '자신을 한 단어로 표현한다면, 어떤 단어가 가장 적합하다고 생각하나요? 그 단어를 닮은 이유를 1분 동안 말해보세요!');
 
+INSERT INTO user(created_at, email, name, oauth_server_id, voice_url, oauth_server, role)
+VALUES ('2024-11-14-00:01:04', 'test@example.com', 'test', '1', 'test voice url', 'KAKAO', 'USER');
 
-INSERT INTO user(email, name, oauth_server_id, voice_url, oauth_server, role) VALUES ('test@example.com','test', '1', 'test voice url', 'KAKAO', 'USER');
+INSERT INTO user(created_at, email, name, oauth_server_id, voice_url, oauth_server, role)
+VALUES ('2024-11-13-00:01:04', 'test2@example.com', 'test2', '2', 'test voice url', 'KAKAO', 'USER');
 
+INSERT INTO answer(created_at, user_id)
+VALUES ('2024-11-13-00:01:05', '2')


### PR DESCRIPTION
## ✅ PR 유형

어떤 **변경 사항**이 있었나요?

- [x] 새로운 기능 추가
- [ ] 디자인 추가 및 수정
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💻 작업 내용

이번 PR에서 작업한 내용에 대해 설명해주세요.

유저가 하단바의 달력 탭을 눌렀을 때, 
> 현재 날짜가 포함된 월 달력< 이 뜨고,
달력 탭을 누르는 순간, 해당  getDatesWhenUserDid Api가 날아감
(달력 탭 내에서 왼쪽 오른쪽 옮겨 가면서 달 기준으로 바꿔갈때도 마찬가지)

api 날릴 때는 "년도" 와 "달"을 query  parameter로 날려주면 되고
return은 
1부터 31까지  Long 배열 만들어 놓고 0으로 초기화,
해당 유저가 인풋으로 온 "년도"와 "달" 내에서 실행한 Day 값을 index로 써서
실행 했으면 해당 answerId 값 (Long type),
실행하지 않았다면  디폴트 값이 0 

자세한건 스웨거 참조

++  user랑 answer 더미 하나씩 더 넣어놓음
(테스트 해보긴 했는데 혹시 오류 있으면 얘기좀) 

## 🖼️ 스크린샷

## 🙏 리뷰 요구사항

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## ✅ 체크리스트(PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
